### PR TITLE
Changes to allow openshift to run on the ec2 instance

### DIFF
--- a/roles/cloud/tasks/main.yml
+++ b/roles/cloud/tasks/main.yml
@@ -18,3 +18,7 @@
   lineinfile: path="{{ item.stdout }}/.bashrc" regexp='^alias minikube=\'sudo /home/ubuntu/bin/minikube\'' line='alias minikube=\'sudo /home/ubuntu/bin/minikube\'' state=present
   with_items:
     - "{{ user_home }}"
+
+- name: Docker registry
+  lineinfile: path="/lib/systemd/system/docker.service" regexp='^ExecStart=/usr/bin/dockerd' line='ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock --insecure-registry 172.30.0.0/16'
+  become: yes

--- a/roles/dev/files/install.sh
+++ b/roles/dev/files/install.sh
@@ -26,3 +26,11 @@ cp minishift-$SHIFTVER-linux-amd64/minishift $1/bin
 chmod +x $1/bin/minishift
 rm minishift-$SHIFTVER-linux-amd64.tgz
 rm -rf minishift-$SHIFTVER-linux-amd64
+
+OPENSHIFTCTL="https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz"
+wget $OPENSHIFTCTL
+tar xzf openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
+cp openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit/oc $1/bin
+chmod +x $1/bin/oc
+rm openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
+rm -rf openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,6 +62,13 @@ resource "aws_security_group" "sg_22" {
   }
 
   ingress {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
       from_port   = 30000
       to_port     = 30000
       protocol    = "tcp"


### PR DESCRIPTION
This PR lets you start an openshift cluster using `oc cluster up`. Additionally it opens up the ports so that you can use an openshift route to get to the cluster.