### PR TITLE
specify k3d version 3.1.2

### DIFF
--- a/roles/dev/tasks/main.yml
+++ b/roles/dev/tasks/main.yml
@@ -9,7 +9,7 @@
   become: yes
 
 - name: Install k3d
-  shell: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+  shell: export TAG=v3.1.2 && curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
 
 - name: Install Golang
   command: snap install go --classic


### PR DESCRIPTION
specify the version to install is 3.1.2.  This is because there was an issue discovered with spire and k3d 3.1.4 (https://github.com/greymatter-io/helm-charts/issues/773).  This ensures version '3.1.2' is installed in the aim instead of the 'latest' version.

to test run `make packer` then `make apply`.  once you have sshed into the ec2 devinabox you will now be able to run `make k3d` since the version is <3.1.4.