### PR TITLE
Removed silver searcher install (#23)

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -64,10 +64,6 @@
   command: snap install tree --classic
   become: yes
 
-- name: Install silver searcher
-  command: snap install ag-mcphail
-  become: yes
-
 - name: Set Git Editor
   command: git config --global core.editor vim
 


### PR DESCRIPTION
The silver searcher package (ag-mcphail) is no longer available for installation. Upon looking through the devinabox repo, this function does not appear to be used and subsequent testing confirmed that devinabox works just fine without it. The silver searcher package installation has been removed from this repo.