### PR TITLE
Added Elastic IP to instance (#21)

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -95,6 +95,11 @@ data "aws_ami" "packer" {
   owners = ["self"]
 }
 
+resource "aws_eip" "eip" {
+  vpc = true
+  instance = aws_instance.instance.id
+}
+
 resource "aws_instance" "instance" {
   ami           = data.aws_ami.packer.id
   instance_type = var.instance_type

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,3 @@
 output "ec2ip" {
-    value = aws_instance.instance.public_ip
+    value = aws_eip.eip.public_ip
 }


### PR DESCRIPTION
Added Elastic IP to the AWS instance. This will prevent the IP from changing if the instance is stopped/started. #21 